### PR TITLE
feat(runbatch): output for functioncommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 **porch** is a sophisticated Go-based process orchestration framework designed for running and managing complex command workflows. It provides a flexible, YAML-driven approach to define, compose, and execute command chains with advanced flow control, parallel processing, and comprehensive error handling.
 
+It was designed to solve the problem of orchestrating complex command workflows in a portable and easy-to-use manner.
+Its portability means that you can confidently run the same workflows locally, in CI/CD pipelines, or on any server without worrying about compatibility issues.
+
 ## ✨ Features
 
 ### 🚀 **Command Orchestration**
@@ -43,6 +46,16 @@
 - **Temporary Directory Support**: Isolated execution environments for testing and builds
 
 ## 📦 Installation
+
+### Operating System Support
+
+Porch currently supports the following operating systems:
+
+- Linux
+- macOS
+
+Porch does compile and run on Windows, but the tests do not pass.
+Therefore it is not officially supported.
 
 ### Install from Go modules
 
@@ -179,7 +192,7 @@ Get information about configuration format and available commands.
 **Usage:**
 
 ```bash
-porch config                    # List all available commands
+porch config                   # List all available commands
 porch config shell             # Show shell command schema and example
 porch config serial --markdown # Show serial command docs in Markdown format
 ```
@@ -205,8 +218,8 @@ Every porch workflow starts with a root configuration that defines the overall s
 ```yaml
 name: "Workflow Name"                    # Required: Descriptive name for the workflow
 description: "Workflow description"      # Optional: Description of what this workflow does
-commands: []                            # Required: List of commands to execute
-command_groups: []                      # Optional: Named groups of commands for reuse
+commands: []                             # Required: List of commands to execute
+command_groups: []                       # Optional: Named groups of commands for reuse
 ```
 
 ### Command Groups
@@ -406,7 +419,7 @@ For each command, an environment variable called `ITEM` is set to the path of th
 
 - `none`: Don't change working directory for child commands
 - `item_relative`: Set working directory relative to the current directory
-- `item_absolute`: Set working directory to the absolute path of each found directory
+- `item_absolute`: **experimental** Set working directory to the absolute path of each found directory
 
 **Example:**
 

--- a/cmd/porch/main.go
+++ b/cmd/porch/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	go signalbroker.Watch(ctx, sigCh, cancel)
 
-	rootCmd.Version = fmt.Sprintf("Porch %s (commit: %s)", porch.Version, porch.Commit)
+	rootCmd.Version = fmt.Sprintf("%s (commit: %s)", porch.Version, porch.Commit)
 
 	factory := commandregistry.New(
 		serialcommand.Register,

--- a/internal/runbatch/functionCommand.go
+++ b/internal/runbatch/functionCommand.go
@@ -133,7 +133,7 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 	res := &Result{
 		Label:    f.Label,
 		ExitCode: 0,
-		Status:   ResultStatusUnknown,
+		Status:   ResultStatusSuccess,
 	}
 
 	// Wait for either the function to complete or the context to be cancelled

--- a/internal/runbatch/functionCommand.go
+++ b/internal/runbatch/functionCommand.go
@@ -87,6 +87,7 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 			if r := recover(); r != nil {
 				// Log the panic
 				logger.Error("Function command panicked", "panic", r)
+
 				var err error
 				switch x := r.(type) {
 				case error:
@@ -110,6 +111,7 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 		}()
 
 		logger.Debug("Running function command")
+
 		startTime := time.Now()
 		startTimeStr := startTime.Format(ctxlog.TimeFormat)
 		fmt.Printf("Executing %s: at %s\n", fullLabel, startTimeStr)
@@ -140,6 +142,7 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 	select {
 	case fr := <-frCh:
 		logger.Debug("Function command result received", "error", fr.Err, "newCwd", fr.NewCwd)
+
 		if fr.Err != nil {
 			return Results{
 				{
@@ -158,6 +161,7 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 
 	case <-ctx.Done():
 		logger.Debug("Function command context cancelled", "error", ctx.Err())
+
 		return Results{
 			{
 				Label:    f.Label,
@@ -169,5 +173,6 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 	}
 
 	logger.Debug("Function command completed successfully", "newCwd", res.newCwd)
+
 	return Results{res}
 }

--- a/internal/runbatch/functionCommand.go
+++ b/internal/runbatch/functionCommand.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
+	"github.com/matt-FFFFFF/porch/internal/ctxlog"
 )
 
 var _ Runnable = (*FunctionCommand)(nil)
@@ -60,8 +63,14 @@ type FunctionCommandReturn struct {
 
 // Run implements the Runnable interface for FunctionCommand.
 func (f *FunctionCommand) Run(ctx context.Context) Results {
+	fullLabel := FullLabel(f)
+	logger := ctxlog.Logger(ctx)
+	logger = logger.With("runnableType", "functionCommand").
+		With("label", fullLabel)
+
 	// Return success immediately if function is nil
 	if f.Func == nil {
+		logger.Debug("No function to run, returning success")
 		return Results{{Label: f.Label, ExitCode: 0, Error: nil}}
 	}
 
@@ -76,6 +85,8 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 		// Recover from panics and convert them to errors
 		defer func() {
 			if r := recover(); r != nil {
+				// Log the panic
+				logger.Error("Function command panicked", "panic", r)
 				var err error
 				switch x := r.(type) {
 				case error:
@@ -88,7 +99,9 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 				select {
 				case <-done:
 					// Already done, don't send on frCh
+					logger.Debug("Function command panic done channel closed, skipping result send")
 				default:
+					logger.Debug("Function command panic sending error", "error", err)
 					frCh <- FunctionCommandReturn{
 						Err: err,
 					}
@@ -96,14 +109,23 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 			}
 		}()
 
+		logger.Debug("Running function command")
+		startTime := time.Now()
+		startTimeStr := startTime.Format(ctxlog.TimeFormat)
+		fmt.Printf("Executing %s: at %s\n", fullLabel, startTimeStr)
+
 		// Run the function
 		fr := f.Func(ctx, f.Cwd)
+
+		logger.Debug("Function command completed", "result", fr)
 
 		// Check if we're done before sending to avoid "send on closed channel"
 		select {
 		case <-done:
+			logger.Debug("Function command done channel closed, skipping result send")
 			// Already done, don't send on frCh
 		default:
+			logger.Debug("Function command sending result", "result", fr)
 			frCh <- fr
 		}
 	}()
@@ -111,11 +133,13 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 	res := &Result{
 		Label:    f.Label,
 		ExitCode: 0,
-		Status:   ResultStatusSuccess,
+		Status:   ResultStatusUnknown,
 	}
+
 	// Wait for either the function to complete or the context to be cancelled
 	select {
 	case fr := <-frCh:
+		logger.Debug("Function command result received", "error", fr.Err, "newCwd", fr.NewCwd)
 		if fr.Err != nil {
 			return Results{
 				{
@@ -127,10 +151,13 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 			}
 		}
 
+		// No error, set new working directory if provided
 		if fr.NewCwd != "" {
 			res.newCwd = fr.NewCwd
 		}
+
 	case <-ctx.Done():
+		logger.Debug("Function command context cancelled", "error", ctx.Err())
 		return Results{
 			{
 				Label:    f.Label,
@@ -141,5 +168,6 @@ func (f *FunctionCommand) Run(ctx context.Context) Results {
 		}
 	}
 
+	logger.Debug("Function command completed successfully", "newCwd", res.newCwd)
 	return Results{res}
 }


### PR DESCRIPTION
This pull request introduces updates to the `README.md` file for improved documentation, refines logging in the `FunctionCommand` implementation, and makes minor adjustments to version formatting in the CLI. The most significant changes focus on enhancing clarity in documentation and adding detailed logging for better debugging and monitoring.

### Documentation Updates:

* Added a description of the portability of `porch` workflows to emphasize compatibility across local environments, CI/CD pipelines, and servers. (`README.md`, [README.mdR5-R7](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R7))
* Introduced a section detailing supported operating systems, clarifying that Windows is not officially supported due to failing tests. (`README.md`, [README.mdR50-R59](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R59))
* Marked the `item_absolute` working directory option as experimental for better transparency. (`README.md`, [README.mdL409-R422](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L409-R422))

### Logging Enhancements:

* Integrated detailed logging in the `FunctionCommand` implementation, including debug logs for execution start, completion, error handling, and context cancellation. (`internal/runbatch/functionCommand.go`, [[1]](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R66-R73) [[2]](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R88-R89) [[3]](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R102-R142) [[4]](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R154-R160) [[5]](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R171)
* Added a logger initialization that associates context-specific metadata, such as `runnableType` and `label`, for improved traceability. (`internal/runbatch/functionCommand.go`, [internal/runbatch/functionCommand.goR66-R73](diffhunk://#diff-ac2bf5ba68b8d24a346e93b947bf5af30427ffc2a5ddce1f9c3f9726e1a0a636R66-R73))

### Minor Adjustments:

* Simplified the version formatting in the CLI by removing the hardcoded "Porch" prefix. (`cmd/porch/main.go`, [cmd/porch/main.goL60-R60](diffhunk://#diff-e72443ea1c7ded6dc3b28a676be750077978be65c5291cb166875bcba8898e4fL60-R60))